### PR TITLE
goを追加

### DIFF
--- a/exec-container/flake.nix
+++ b/exec-container/flake.nix
@@ -16,6 +16,10 @@
           inherit pkgs;
           inherit filter;
         };
+        golang = import ./golang/golang.nix {
+          inherit pkgs;
+          inherit filter;
+        };
       in
       {
         packages = {
@@ -23,6 +27,7 @@
             name = "default-all";
             paths = [
               python-all
+              golang
             ];
           };
         };

--- a/exec-container/golang/compiler.nix
+++ b/exec-container/golang/compiler.nix
@@ -1,0 +1,22 @@
+{
+  pkgs, filter, ...
+}:
+let
+  golang = pkgs.go;
+in
+  pkgs.stdenv.mkDerivation {
+    name = "golang";
+    src = filter {
+      root = golang;
+      /*
+       */
+      include = [
+        "share/go/bin/go"
+      ];
+    };
+    phases = "installPhase";
+    installPhase = ''
+      mkdir -p $out/bin
+      ln -s $src/share/go/bin/go $out/bin/go
+    '';
+  }

--- a/exec-container/golang/golang.nix
+++ b/exec-container/golang/golang.nix
@@ -1,0 +1,13 @@
+{
+  pkgs, filter, ...
+}: let
+  compiler = import ./compiler.nix { inherit pkgs; inherit filter; };
+  vendor = import ./library.nix { inherit pkgs; };
+in
+  pkgs.symlinkJoin {
+    name = "python-all";
+    paths = [
+      compiler
+      vendor
+    ];
+  }

--- a/exec-container/golang/library.nix
+++ b/exec-container/golang/library.nix
@@ -1,0 +1,40 @@
+{
+  pkgs, ...
+}:
+let
+  gods = builtins.fetchGit {
+    url = "https://github.com/emirpasic/gods";
+    rev = "dbdbadc158ae6b453820b3cfb8c6cb48be4d7ddf"; # v1.18.1
+  };
+  gonum = builtins.fetchGit {
+    url = "https://github.com/gonum/gonum";
+    rev = "bdcda9a453049449163d160b98285b64ec8093a1"; # v0.15.1
+  };
+  gostl = builtins.fetchGit {
+    url = "https://github.com/liyue201/gostl";
+    rev = "98dc0eb1ce1063cf860342e7e890760fcb711e3b"; # v1.2.0
+  };
+  golang-org-x-exp = builtins.fetchGit {
+    url = "https://github.com/golang/exp";
+    rev = "225e2abe05e664228e7afb6bf5b97a25d56ba575"; # v0.0.0-20241009180824-f66d83c29e7c (via GitHub)
+  };
+in
+  pkgs.stdenv.mkDerivation {
+    name = "go-library";
+    description = "Libraries for Go";
+    phases = "installPhase";
+    byuidInputs = [
+      gods
+      gonum
+      gostl
+      golang-org-x-exp
+    ];
+    src = ./.;
+    installPhase = ''
+      mkdir -p $out/cache/go
+      ln -s ${gods} $out/cache/go/gods
+      ln -s ${gonum} $out/cache/go/gonum
+      ln -s ${gostl} $out/cache/go/gostl
+      ln -s ${golang-org-x-exp} $out/cache/go/exp
+    '';
+  }


### PR DESCRIPTION
close #38 
- `bin/go`を追加
- 'cache/go`の下にgods, gonum, gostl, expのソースを追加