### PR TITLE
goを追加

### DIFF
--- a/exec-container/compilers/default.nix
+++ b/exec-container/compilers/default.nix
@@ -1,4 +1,7 @@
 {pkgs}: let
+  golang = import ./golang {inherit pkgs;};
 in {
-  all = [];
+  all = [
+    golang
+  ];
 }

--- a/exec-container/compilers/golang/compiler.nix
+++ b/exec-container/compilers/golang/compiler.nix
@@ -1,0 +1,4 @@
+{pkgs}: let
+  goCompiler = pkgs.go;
+in
+  pkgs.writeShellScriptBin "go" "exec ${goCompiler}/share/go/bin/go $@"

--- a/exec-container/compilers/golang/default.nix
+++ b/exec-container/compilers/golang/default.nix
@@ -1,0 +1,8 @@
+{pkgs}: let
+  goCompiler = import ./compiler.nix {inherit pkgs;};
+  goMod = import ./go-mod.nix {inherit pkgs;};
+in
+  pkgs.symlinkJoin {
+    name = "golang";
+    paths = [goCompiler goMod];
+  }

--- a/exec-container/compilers/golang/go-mod.nix
+++ b/exec-container/compilers/golang/go-mod.nix
@@ -35,10 +35,10 @@ in
       )
 
       replace (
-          github.com/emirpasic/gods => ${gods} v1.18.1
-          github.com/gonum/gonum => ${gonum} v0.15.1
-          github.com/liyue201/gostl => ${gostl} v1.2.0
-          golang.org/x/exp => ${golang-org-x-exp} v0.0.0-20241009180824-f66d83c29e7c
+          github.com/emirpasic/gods => ${gods}
+          github.com/gonum/gonum => ${gonum}
+          github.com/liyue201/gostl => ${gostl}
+          golang.org/x/exp => ${golang-org-x-exp}
       )
       ' > $out/misc/go/go.mod
     '';

--- a/exec-container/compilers/golang/go-mod.nix
+++ b/exec-container/compilers/golang/go-mod.nix
@@ -1,45 +1,28 @@
-{pkgs, ...}: let
-  gods = builtins.fetchGit {
-    url = "https://github.com/emirpasic/gods";
-    rev = "dbdbadc158ae6b453820b3cfb8c6cb48be4d7ddf"; # v1.18.1
-  };
-  gonum = builtins.fetchGit {
-    url = "https://github.com/gonum/gonum";
-    rev = "bdcda9a453049449163d160b98285b64ec8093a1"; # v0.15.1
-  };
-  gostl = builtins.fetchGit {
-    url = "https://github.com/liyue201/gostl";
-    rev = "98dc0eb1ce1063cf860342e7e890760fcb711e3b"; # v1.2.0
-  };
-  golang-org-x-exp = builtins.fetchGit {
-    url = "https://github.com/golang/exp";
-    rev = "225e2abe05e664228e7afb6bf5b97a25d56ba575"; # v0.0.0-20241009180824-f66d83c29e7c (via GitHub)
-  };
-in
-  pkgs.stdenv.mkDerivation {
-    name = "go.mod template";
-    src = ./.;
-    phases = "installPhase";
-    installPhase = ''
-      mkdir -p $out/misc/go
-      touch $out/misc/go/go.mod
-      echo 'module gomod-template
+{pkgs, ...}:
+pkgs.stdenv.mkDerivation {
+  name = "go.mod template";
+  src = ./.;
+  phases = "installPhase";
+  installPhase = ''
+    mkdir -p $out/misc/go
+    touch $out/misc/go/go.mod
+    echo 'module gomod-template
 
-      go 1.23.2
+    go 1.23.2
 
-      require (
-          github.com/emirpasic/gods v1.18.1
-          github.com/gonum/gonum v0.15.1
-          github.com/liyue201/gostl v1.2.0
-          golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
-      )
+    require (
+        github.com/emirpasic/gods v1.18.1
+        github.com/gonum/gonum v0.15.1
+        github.com/liyue201/gostl v1.2.0
+        golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
+    )
 
-      replace (
-          github.com/emirpasic/gods => ${gods}
-          github.com/gonum/gonum => ${gonum}
-          github.com/liyue201/gostl => ${gostl}
-          golang.org/x/exp => ${golang-org-x-exp}
-      )
-      ' > $out/misc/go/go.mod
-    '';
-  }
+    replace (
+        github.com/emirpasic/gods => ${pkgs.myGoLibraries.gods}
+        github.com/gonum/gonum => ${pkgs.myGoLibraries.gonum}
+        github.com/liyue201/gostl => ${pkgs.myGoLibraries.gostl}
+        golang.org/x/exp => ${pkgs.myGoLibraries.golang-org-exp}
+    )
+    ' > $out/misc/go/go.mod
+  '';
+}

--- a/exec-container/compilers/golang/go-mod.nix
+++ b/exec-container/compilers/golang/go-mod.nix
@@ -1,0 +1,45 @@
+{pkgs, ...}: let
+  gods = builtins.fetchGit {
+    url = "https://github.com/emirpasic/gods";
+    rev = "dbdbadc158ae6b453820b3cfb8c6cb48be4d7ddf"; # v1.18.1
+  };
+  gonum = builtins.fetchGit {
+    url = "https://github.com/gonum/gonum";
+    rev = "bdcda9a453049449163d160b98285b64ec8093a1"; # v0.15.1
+  };
+  gostl = builtins.fetchGit {
+    url = "https://github.com/liyue201/gostl";
+    rev = "98dc0eb1ce1063cf860342e7e890760fcb711e3b"; # v1.2.0
+  };
+  golang-org-x-exp = builtins.fetchGit {
+    url = "https://github.com/golang/exp";
+    rev = "225e2abe05e664228e7afb6bf5b97a25d56ba575"; # v0.0.0-20241009180824-f66d83c29e7c (via GitHub)
+  };
+in
+  pkgs.stdenv.mkDerivation {
+    name = "go.mod template";
+    src = ./.;
+    phases = "installPhase";
+    installPhase = ''
+      mkdir -p $out/misc/go
+      touch $out/misc/go/go.mod
+      echo 'module gomod-template
+
+      go 1.23.2
+
+      require (
+          github.com/emirpasic/gods v1.18.1
+          github.com/gonum/gonum v0.15.1
+          github.com/liyue201/gostl v1.2.0
+          golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
+      )
+
+      replace (
+          github.com/emirpasic/gods => ${gods} v1.18.1
+          github.com/gonum/gonum => ${gonum} v0.15.1
+          github.com/liyue201/gostl => ${gostl} v1.2.0
+          golang.org/x/exp => ${golang-org-x-exp} v0.0.0-20241009180824-f66d83c29e7c
+      )
+      ' > $out/misc/go/go.mod
+    '';
+  }

--- a/exec-container/flake.nix
+++ b/exec-container/flake.nix
@@ -2,15 +2,45 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    gods = {
+      url = "github:emirpasic/gods/v1.18.1";
+      flake = false;
+    };
+    gonum = {
+      url = "github:gonum/gonum/v0.15.1";
+      flake = false;
+    };
+    gostl = {
+      url = "github:liyue201/gostl/v1.2.0";
+      flake = false;
+    };
+    golang-org-exp = {
+      # No version tag available in the repository. (v0.0.0-20241009180824-f66d83c29e7c)
+      url = "github:golang/exp/225e2abe05e664228e7afb6bf5b97a25d56ba575";
+      flake = false;
+    };
   };
 
   outputs = {
     self,
     nixpkgs,
     flake-utils,
+    gods,
+    gonum,
+    gostl,
+    golang-org-exp,
   }:
     flake-utils.lib.eachDefaultSystem (system: let
-      pkgs = nixpkgs.legacyPackages.${system};
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [
+          (final: prev: {
+            myGoLibraries = {
+              inherit gods gonum gostl golang-org-exp;
+            };
+          })
+        ];
+      };
     in {
       packages.default = import ./docker-image.nix {inherit pkgs;};
       formatter = pkgs.alejandra;


### PR DESCRIPTION
close #38
# 変更点
- `/bin/go`を追加
- `/misc/go/go.mod`を追加し、gods, gostl, gonum, expを利用したコードをオフラインでコンパイルできるように