### PR TITLE
✨ brainfuck compiler

### DIFF
--- a/exec-container/compilers/brainfuck/default.nix
+++ b/exec-container/compilers/brainfuck/default.nix
@@ -1,0 +1,5 @@
+{pkgs, ...}: let
+  myBrainfuck = pkgs.bfc;
+  myClang = pkgs.clang;
+in
+  pkgs.writeShellScriptBin "bfc" "PATH=${myClang}/bin:$PATH exec ${myBrainfuck}/bin/bfc $@"

--- a/exec-container/compilers/default.nix
+++ b/exec-container/compilers/default.nix
@@ -1,7 +1,9 @@
 {pkgs}: let
   golang = import ./golang {inherit pkgs;};
+  brainfuck = import ./brainfuck {inherit pkgs;};
 in {
   all = [
     golang
+    brainfuck
   ];
 }

--- a/exec-container/docker-image.nix
+++ b/exec-container/docker-image.nix
@@ -5,5 +5,5 @@ in
   pkgs.dockerTools.buildImage {
     name = "exec-container";
 
-    copyToRoot = interpreters.all ++ compilers.all ++ [pkgs.bash pkgs.coreutils];
+    copyToRoot = interpreters.all ++ compilers.all;
   }

--- a/exec-container/docker-image.nix
+++ b/exec-container/docker-image.nix
@@ -5,5 +5,5 @@ in
   pkgs.dockerTools.buildImage {
     name = "exec-container";
 
-    copyToRoot = interpreters.all ++ compilers.all;
+    copyToRoot = interpreters.all ++ compilers.all ++ [pkgs.bash pkgs.coreutils];
   }


### PR DESCRIPTION
close #53
- `/bin/bfc`を追加

brainfuckのC実装です。ビルドにclangを使うので`pkgs.clang`を入れたのですが、clangそのものも導入する予定なので必要ない気もしています。