### PR TITLE
clangのコンパイルコマンドを修正

### DIFF
--- a/exec-container/compilers/clang/default.nix
+++ b/exec-container/compilers/clang/default.nix
@@ -17,7 +17,7 @@ in
       languages = [
         {
           binName = "clang++";
-          compile = "${myClang}/bin/g++ -std=c++23 -o $OUT $SRC";
+          compile = "${myClang}/bin/clang++ -std=c++23 -o $OUT $SRC";
           name = "C++(clang)";
           run = "$OUT";
         }


### PR DESCRIPTION
g++になっていたのを、clang++にした

## issue
close #204

## チェックリスト(nix)
- [x] ビルドが通る
- [x] license-check.shが通る
