### PR TITLE
Fix/#208 change command envvars

### DIFF
--- a/exec-container/compilers/brainfuck/default.nix
+++ b/exec-container/compilers/brainfuck/default.nix
@@ -7,7 +7,7 @@ in
     traojudge = {
       name = "Brainfuck";
       binName = "bfc";
-      compile = "${myBrainfuck} \"$SRC\"";
-      run = "exec \"$DIST\""; # TODO: bfcは出力ファイルを指定できなさそうなので、これは変えないといけない
+      compile = cfg: "${myBrainfuck} \"$SRC\"";
+      run = cfg: "exec \"$DIST\""; # TODO: bfcは出力ファイルを指定できなさそうなので、これは変えないといけない
     };
   }

--- a/exec-container/compilers/clang/default.nix
+++ b/exec-container/compilers/clang/default.nix
@@ -17,9 +17,10 @@ in
       languages = [
         {
           binName = "clang++";
-          compile = "${myClang}/bin/clang++ -std=c++23 -o $OUT $SRC";
+          compile = cfg: "${pkgs.coreutils}/bin/cp ${cfg.src} ${cfg.temp}/main.cpp && \
+            ${myClang}/bin/clang++ -std=c++23 -o ${cfg.out} ${cfg.temp}/main.cpp -lgmpxx -lgmp -lz3";
           name = "C++(clang)";
-          run = "$OUT";
+          run = cfg: "exec ${cfg.out}";
         }
       ];
     };

--- a/exec-container/compilers/g++/default.nix
+++ b/exec-container/compilers/g++/default.nix
@@ -16,9 +16,9 @@ in
       languages = [
         {
           binName = "g++";
-          compile = "${myGcc}/bin/g++ -std=c++23 -o $OUT $SRC";
+          compile = cfg: "${myGcc}/bin/g++ -std=c++23 -o ${cfg.out} ${cfg.src} -lgmpxx -lgmp";
           name = "C++(g++)";
-          run = "$OUT";
+          run = cfg: "exec ${cfg.out}";
         }
       ];
     };

--- a/exec-container/compilers/gcc/default.nix
+++ b/exec-container/compilers/gcc/default.nix
@@ -7,9 +7,9 @@ in
       languages = [
         {
           binName = "gcc";
-          compile = "${myGcc}/bin/gcc -o $OUT $SRC";
+          compile = cfg: "${myGcc}/bin/gcc -o ${cfg.out} ${cfg.src}";
           name = "C";
-          run = "$OUT";
+          run = cfg: "exec ${cfg.out}";
         }
       ];
     };

--- a/exec-container/compilers/java/default.nix
+++ b/exec-container/compilers/java/default.nix
@@ -16,12 +16,12 @@ in
       languages = [
         {
           binName = "java";
-          compile = ''
-            ln -s $SRC $DEST/Main.java
-            ${openjdk}/bin/javac $DEST/Main.java
+          compile = cfg: ''
+            ln -s ${cfg.src} ${cfg.out}/Main.java
+            ${openjdk}/bin/javac ${cfg.out}/Main.java
           '';
           name = "Java";
-          run = "${openjdk}/bin/java $DEST/Main";
+          run = cfg: "${openjdk}/bin/java ${cfg.out}/Main";
         }
       ];
     };

--- a/exec-container/interpreters/malbolge/default.nix
+++ b/exec-container/interpreters/malbolge/default.nix
@@ -20,9 +20,9 @@ in
       languages = [
         {
           binName = "malbolge";
-          compile = "";
+          compile = cfg: "";
           name = "Malbolge";
-          run = "${malbolge}/bin/malbolge \"$SRC\"";
+          run = cfg: "${malbolge}/bin/malbolge \"${cfg.src}\"";
         }
       ];
     };

--- a/exec-container/interpreters/python/3.11/default.nix
+++ b/exec-container/interpreters/python/3.11/default.nix
@@ -21,8 +21,8 @@ in
     traojudge = {
       name = "Python3.11";
       binName = "python3.11";
-      compile = "cp \"$SRC\" \"$DIST\"";
-      run = "exec ${myPython}/bin/python \"$DIST\"";
+      compile = cfg: "${pkgs.coreutils}/bin/cp ${cfg.src} ${cfg.out}/main.py";
+      run = cfg: "exec ${myPython}/bin/python ${cfg.out}/main.py";
       #libraries = [
       #  バージョンが指定されていないので書けない
       #]

--- a/exec-container/interpreters/python/3.12-quantum/default.nix
+++ b/exec-container/interpreters/python/3.12-quantum/default.nix
@@ -46,8 +46,8 @@ in
     traojudge = {
       name = "Python3.12-quantum";
       binName = "python3.12-quantum";
-      compile = "cp \"$SRC\" \"$DIST\"";
-      run = "exec ${python-modified}/bin/python \"$DIST\"";
+      compile = cfg: "${pkgs.coreutils}/bin/cp ${cfg.src} ${cfg.out}/main.py";
+      run = cfg: "exec ${python-modified}/bin/python ${cfg.out}/main.py";
       libraries = [
         {
           name = "qiskit";

--- a/exec-container/interpreters/python/3.12/default.nix
+++ b/exec-container/interpreters/python/3.12/default.nix
@@ -21,8 +21,8 @@ in
     traojudge = {
       name = "Python3.12";
       binName = "python3.12";
-      compile = "cp \"$SRC\" \"$DIST\"";
-      run = "exec ${myPython}/bin/python \"$DIST\"";
+      compile = cfg: "${pkgs.coreutils}/bin/cp ${cfg.src} ${cfg.out}/main.py";
+      run = cfg: "exec ${myPython}/bin/python ${cfg.out}/main.py";
       #libraries = [
       #  バージョンが指定されていないので書けない
       #]

--- a/exec-container/languageSettings.nix
+++ b/exec-container/languageSettings.nix
@@ -11,10 +11,12 @@
     temp = "$TRAOJUDGE_BUILD_TEMPDIR";
   };
   languagesArray = {
-    languages = builtins.map (lang: lang // {
-      compile = lang.compile cfg;
-      run = lang.run cfg;
-    }) (interpreters.traojudge ++ compilers.traojudge);
+    languages = builtins.map (lang:
+      lang
+      // {
+        compile = lang.compile cfg;
+        run = lang.run cfg;
+      }) (interpreters.traojudge ++ compilers.traojudge);
   };
   jsonOutput = builtins.toJSON languagesArray;
   jsonFile = pkgs.writeText "languages.json" jsonOutput;

--- a/exec-container/languageSettings.nix
+++ b/exec-container/languageSettings.nix
@@ -5,8 +5,16 @@
   interpreters = import ./interpreters {inherit allpkgs;};
   compilers = import ./compilers {inherit allpkgs;};
 
+  cfg = {
+    src = "$TRAOJUDGE_BUILD_SOURCE";
+    out = "$TRAOJUDGE_BUILD_OUTPUT";
+    temp = "$TRAOJUDGE_BUILD_TEMPDIR";
+  };
   languagesArray = {
-    languages = interpreters.traojudge ++ compilers.traojudge;
+    languages = builtins.map (lang: lang // {
+      compile = lang.compile cfg;
+      run = lang.run cfg;
+    }) (interpreters.traojudge ++ compilers.traojudge);
   };
   jsonOutput = builtins.toJSON languagesArray;
   jsonFile = pkgs.writeText "languages.json" jsonOutput;


### PR DESCRIPTION
## issue
close #208

languageSettings.nixで環境変数を一括で管理できるように、各言語のコマンドを環境変数の値のattrsetを受け取ってコマンドを返す関数に変更しました。
jsonが出力されることを確認済み

## チェックリスト(nix)
- [x] ビルドが通る
- [x] license-check.shが通る
