### PR TITLE
認証周りの情報を拡充

### DIFF
--- a/api/backend/frontend-backend.yaml
+++ b/api/backend/frontend-backend.yaml
@@ -1133,31 +1133,30 @@ components:
       type: object
       description: ユーザーの認証情報
       properties:
-        hasEmailAuth:
-          type: boolean
-          description: メール+パスワード認証が設定されているか
-        hasGoogleAuth:
-          type: boolean
-          description: Google認証が連携されているか
-        hasGithubAuth:
-          type: boolean
-          description: GitHub認証が連携されているか
-        email:
+        emailAuth:
           type: string
           format: email
-          description: 認証用メールアドレス
+          description: メール認証用のアドレス（存在すればメール認証可能）
+          nullable: true
         emailVerified:
           type: boolean
-          description: メールが確認済みか
-        hasTraqAuth:
+          description: メールが確認済みかどうか
+          default: false
+        googleAuth:
           type: string
-          description: traQ認証が連携されているか
+          format: email
+          description: Google認証に使用されているメールアドレス（存在すればGoogle認証済み）
+          nullable: true
+        githubAuth:
+          type: string
+          description: GitHub認証に使用されている識別子（存在すればGitHub認証済み）
+          nullable: true
+        traqAuth:
+          type: string
+          description: traQ認証に使用されている識別子（存在すればtraQ認証済み）
+          nullable: true
       required:
-        - hasEmailAuth
-        - hasGoogleAuth
-        - hasGithubAuth
         - emailVerified
-        - hasTraqAuth
     Me:
       title: Me
       type: object

--- a/api/backend/frontend-backend.yaml
+++ b/api/backend/frontend-backend.yaml
@@ -1098,9 +1098,6 @@ components:
         name:
           type: string
           description: ユーザー名
-        traqId:
-          type: string
-          description: traQのID
         githubId:
           type: string
           description: GitHubのID

--- a/api/backend/frontend-backend.yaml
+++ b/api/backend/frontend-backend.yaml
@@ -1135,10 +1135,6 @@ components:
           format: email
           description: メール認証用のアドレス（存在すればメール認証可能）
           nullable: true
-        emailVerified:
-          type: boolean
-          description: メールが確認済みかどうか
-          default: false
         googleAuth:
           type: string
           format: email
@@ -1152,8 +1148,6 @@ components:
           type: string
           description: traQ認証に使用されている識別子（存在すればtraQ認証済み）
           nullable: true
-      required:
-        - emailVerified
     Me:
       title: Me
       type: object

--- a/api/backend/frontend-backend.yaml
+++ b/api/backend/frontend-backend.yaml
@@ -449,7 +449,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/Me'
         '401':
           description: |-
             Unauthorized
@@ -464,7 +464,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/Me'
         '400':
           description: 不正なリクエストです
       tags:
@@ -1128,6 +1128,48 @@ components:
         - role
         - createdAt
         - updatedAt
+    UserAuthentication:
+      title: UserAuthentication
+      type: object
+      description: ユーザーの認証情報
+      properties:
+        hasEmailAuth:
+          type: boolean
+          description: メール+パスワード認証が設定されているか
+        hasGoogleAuth:
+          type: boolean
+          description: Google認証が連携されているか
+        hasGithubAuth:
+          type: boolean
+          description: GitHub認証が連携されているか
+        email:
+          type: string
+          format: email
+          description: 認証用メールアドレス
+        emailVerified:
+          type: boolean
+          description: メールが確認済みか
+        hasTraqAuth:
+          type: string
+          description: traQ認証が連携されているか
+      required:
+        - hasEmailAuth
+        - hasGoogleAuth
+        - hasGithubAuth
+        - emailVerified
+        - hasTraqAuth
+    Me:
+      title: Me
+      type: object
+      description: ログインユーザー自身の詳細情報
+      allOf:
+        - $ref: '#/components/schemas/User'
+        - type: object
+          properties:
+            authentication:
+              $ref: '#/components/schemas/UserAuthentication'
+          required:
+            - authentication
     PutMeRequest:
       title: PutMeRequest
       type: object
@@ -1137,10 +1179,14 @@ components:
         icon:
           type: string
           format: binary
-        xLink:
+        xId:
           type: string
-        githubLink:
+          x-stoplight:
+            id: f3asn9h8jlzvr
+        githubId:
           type: string
+          x-stoplight:
+            id: e0hrxedlfimd4
         selfIntroduction:
           type: string
     PutPasswordRequest:
@@ -1772,4 +1818,4 @@ components:
           - login
           - signup
           - bind
-      description: OAuthのアクション（login, signup, bind）
+      description: 'OAuthのアクション（login, signup, bind）'


### PR DESCRIPTION
認証周りの情報(メールアドレスやどのOAuthを使っているか)をgetMeに限って取得できるようにし，それに伴って新しい構造体を定義した

## チェックリスト(nix)
- [ ] ビルドが通る
- [ ] license-check.shが通る
